### PR TITLE
Mention GNU parallel in the description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ladon",
   "version": "1.0.5",
-  "description": "Run commands in parallel on many files",
+  "description": "Run commands in parallel on many files, like GNU parallel",
   "main": "ladon.js",
   "bin": {
     "ladon": "ladon.js"


### PR DESCRIPTION
I was looking for a GNU parallel-like implementation in npm for a while and I almost missed `ladon`. I find it likely that plenty of people know about GNU parallel and would use that search term to find a related tool.

Perhaps this change would allow `ladon` to be found easier on npm and become more popular?
